### PR TITLE
fix: update Lambda body to work with latest NodeJS Lambda runtime

### DIFF
--- a/creating-a-lambda-function-using-the-aws-console/index.mjs
+++ b/creating-a-lambda-function-using-the-aws-console/index.mjs
@@ -1,7 +1,7 @@
-const https = require('https')
+import https from "https";
 let url = "https://www.amazon.com" 
 
-exports.handler = function(event, context, callback) { 
+export const handler = (event, context, callback) => { 
 	https.get(url, (res) => { 
   		    callback(null, res.statusCode) 	
     	}).on('error', (e) => { 


### PR DESCRIPTION
On latest (July 2023) version of Lambda, If you select the default runtime for NodeJS, it will generate a .mjs instead of .js, and the code in this repo will throw Errors.

Used for hands on lab, "Creating a Lambda Function Using the AWS Console".